### PR TITLE
Fix obfs4 import and a data writing issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,9 @@ func Obfs4_accept(id int) {
 //export Obfs4_write
 func Obfs4_write(listener_id int, buffer unsafe.Pointer, buffer_length C.int) int {
 	var connection = conns[listener_id]
+	if connection == nil {
+		return -1
+	}
 	var bytesBuffer = C.GoBytes(buffer, buffer_length)
 	numberOfBytesWritten, error := connection.Write(bytesBuffer)
 
@@ -64,6 +67,9 @@ func Obfs4_read(listener_id int, buffer unsafe.Pointer, buffer_length C.int) int
 
 	var connection = conns[listener_id]
 	var bytesBuffer = C.GoBytes(buffer, buffer_length)
+	if connection == nil {
+		return -1
+	}
 
 	numberOfBytesRead, error := connection.Read(bytesBuffer)
 
@@ -78,6 +84,9 @@ func Obfs4_read(listener_id int, buffer unsafe.Pointer, buffer_length C.int) int
 func Obfs4_close_connection(listener_id int) {
 
 	var connection = conns[listener_id]
+	if connection == nil {
+		return
+	}
 	connection.Close()
 	delete(conns, listener_id)
 }

--- a/main.go
+++ b/main.go
@@ -4,11 +4,10 @@ import "C"
 import (
 	"net"
 	"unsafe"
-
-	"github.com/OperatorFoundation/shapeshifter-transports/transports/obfs4"
+	"github.com/OperatorFoundation/shapeshifter-transports/transports/obfs4/v2"
 )
 
-var transports = map[int]*obfs4.Obfs4Transport{}
+var transports = map[int]*obfs4.Transport{}
 var listeners = map[int]net.Listener{}
 var conns = map[int]net.Conn{}
 var nextID = 0
@@ -16,7 +15,7 @@ var nextID = 0
 //export Obfs4_initialize_server
 func Obfs4_initialize_server(stateDir *C.char) (listenerKey int) {
 	goStateString := C.GoString(stateDir)
-	var transport *obfs4.Obfs4Transport = obfs4.NewObfs4Server(goStateString)
+	transport, _ := obfs4.NewObfs4Server(goStateString)
 	transports[nextID] = transport
 
 	// This is the return value

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import "C"
 import (
 	"net"
 	"unsafe"
+	"reflect"
 	"github.com/OperatorFoundation/shapeshifter-transports/transports/obfs4/v2"
 )
 
@@ -63,13 +64,13 @@ func Obfs4_write(listener_id int, buffer unsafe.Pointer, buffer_length C.int) in
 }
 
 //export Obfs4_read
-func Obfs4_read(listener_id int, buffer unsafe.Pointer, buffer_length C.int) int {
-
+func Obfs4_read(listener_id int, buffer unsafe.Pointer, buffer_length int) int {
 	var connection = conns[listener_id]
-	var bytesBuffer = C.GoBytes(buffer, buffer_length)
 	if connection == nil {
 		return -1
 	}
+	header := reflect.SliceHeader{uintptr(buffer), buffer_length, buffer_length}
+	bytesBuffer := *(*[]byte)(unsafe.Pointer(&header))
 
 	numberOfBytesRead, error := connection.Read(bytesBuffer)
 


### PR DESCRIPTION
At some point the `shapeshifter-transports` dependency changed and broke compilation for this repo. I made changes to make it compile again. Additionally I added a few nil check to prevent crashes.  

I also found a bug when data is read. Before the go code would use `C.GoBytes` to convert data, but that function will allocate new memory rather than using shared memory. Instead I use reflection to create a byte array where the head is pointing to the start of the shared memory space. 